### PR TITLE
Fix AudioButton not being imported

### DIFF
--- a/scripts/components/Main.js
+++ b/scripts/components/Main.js
@@ -6,6 +6,7 @@ import ModelViewer from './ModelViewer/ModelViewer';
 import Dialog from './Dialog/Dialog';
 import InteractionContent from './Dialog/InteractionContent';
 import ToolBar from './Toolbar/Toolbar';
+import AudioButton from './HUD/Buttons/AudioButton.js';
 
 export default class Main extends React.Component {
   constructor(props) {


### PR DESCRIPTION
When merged in, will import AudioButton to Main.js, so using hotspots with audio content works.

Fixes https://github.com/codefluegel/h5p-modelviewer/issues/1